### PR TITLE
Redirect legacy tdt.akvo.org domain to drylandsinvest.org

### DIFF
--- a/self-hosted/helper/generate_dynamic_config.sh
+++ b/self-hosted/helper/generate_dynamic_config.sh
@@ -39,6 +39,28 @@ http:
       middlewares:
         - cms-stripprefix
 
+    # Legacy domain (tdt.akvo.org) moved to drylandsinvest.org. Search engines
+    # still hold the old URLs, so we keep these routers to issue a permanent
+    # (301) redirect that preserves the path. The 443 router exists mainly so
+    # Traefik obtains a Let's Encrypt cert for the old domain; without it,
+    # HTTPS hits would fail the TLS handshake before the redirect could fire.
+    old-domain-router-80:
+      rule: "Host(\`tdt.akvo.org\`)"
+      service: frontend-service
+      entrypoints: web
+      middlewares:
+        - old-domain-redirect
+
+    old-domain-router-443:
+      entrypoints:
+        - websecure
+      rule: "Host(\`tdt.akvo.org\`)"
+      service: frontend-service
+      tls:
+        certResolver: myresolver
+      middlewares:
+        - old-domain-redirect
+
 
   middlewares:
     redirect-to-https:
@@ -49,6 +71,15 @@ http:
       stripPrefix:
         prefixes:
           - "/cms"
+    # Path-preserving 301 to the new domain. The regex captures everything
+    # after the host so /some/page lands on the same path on drylandsinvest.org,
+    # which keeps per-URL search ranking signals intact. Matching http? as well
+    # collapses plain-HTTP hits into a single redirect to the new HTTPS URL.
+    old-domain-redirect:
+      redirectRegex:
+        regex: "^https?://tdt\\.akvo\\.org/(.*)"
+        replacement: "https://drylandsinvest.org/\${1}"
+        permanent: true
 
 
   services:


### PR DESCRIPTION
## Summary

The site moved from `tdt.akvo.org` to `drylandsinvest.org`, but search engines still hold the old URLs. This adds two Traefik routers for the old host plus a `redirectRegex` middleware that issues a **path-preserving 301** to the new domain, so indexed deep links keep their per-URL ranking signals instead of all collapsing onto the homepage.

## Details

- **Two routers** (`web`/80 and `websecure`/443) for `Host(tdt.akvo.org)`. The redirect regex matches both schemes, so the 443 router is mainly there to make Traefik obtain a Let's Encrypt cert for the old domain — without it, HTTPS hits from crawlers would fail the TLS handshake before the redirect could fire.
- Both routers name `frontend-service` only because Traefik requires every router to reference a service; the redirect short-circuits before any traffic reaches it.

## Required before this works

Repoint `tdt.akvo.org` DNS back to this server, so the routers receive traffic and the ACME HTTP-01 challenge can issue the cert.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215791820220422