### PR TITLE
Fix invalid YAML escape in old-domain redirect regex

### DIFF
--- a/self-hosted/helper/generate_dynamic_config.sh
+++ b/self-hosted/helper/generate_dynamic_config.sh
@@ -77,8 +77,11 @@ http:
     # collapses plain-HTTP hits into a single redirect to the new HTTPS URL.
     old-domain-redirect:
       redirectRegex:
-        regex: "^https?://tdt\\.akvo\\.org/(.*)"
-        replacement: "https://drylandsinvest.org/\${1}"
+        # Single-quoted YAML: backslashes pass through literally to the regex
+        # engine. Double quotes would make YAML choke on \. as an invalid
+        # escape and reject the whole dynamic config.
+        regex: '^https?://tdt\\.akvo\\.org/(.*)'
+        replacement: 'https://drylandsinvest.org/\${1}'
         permanent: true
 
 


### PR DESCRIPTION
## Summary

Hotfix for the staging outage introduced by #67. The old-domain redirect regex was emitted as a YAML **double-quoted** string:

```
regex: "^https?://tdt\.akvo\.org/(.*)"
```

`\.` is not a valid escape sequence in a YAML double-quoted scalar, so Traefik rejected the **entire** generated `dynamic.yml`. With no routers loaded, Traefik answered every request — including staging's own host `tdt.akvotest.org` — with its default **404 page not found**, taking the whole site down rather than just the redirect.

## Fix

Switch the regex and replacement to **single-quoted** YAML scalars, where backslashes pass through literally to Traefik's regex engine. This is the usual way to carry regex patterns in Traefik YAML; doubling every backslash inside double quotes is harder to read and easy to get wrong.

## Verification

- Generated `dynamic.yml` now parses cleanly; all six routers load (including the frontend router that serves staging).
- Parsed regex value is the literal `^https?://tdt\.akvo\.org/(.*)`.
- Regex matches `tdt.akvo.org` on both http/https and does **not** match `tdt.akvotest.org`, so staging serves normally and only production redirects.
